### PR TITLE
Scripts in tools folder, fix bbox in COCO

### DIFF
--- a/main.py
+++ b/main.py
@@ -175,7 +175,7 @@ def main(
                 coco_area = rle_annotation[1]
                 coco_iscrowd = 1
 
-            coco_bbox = get_bbox_based_on_mask(mask_from_generated_photo)
+            coco_bbox = get_bbox_based_on_mask(mask_for_rubbish)
 
             # Add annotation to COCO file
             add_annotation_to_coco(

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,31 @@
+# Tools
+This folder contains helpful scripts for various operations related to handling annotations and visualizing bounding boxes and masks. 
+## Scripts
+1. **json_to_yolo_format_converter.py**: 
+
+This script converts a standard polygon COCO JSON file into TXT YOLO format files, storing them inside the 'bboxes' and 'polygons' folders. The following arguments are required:
+```bash
+python3 json_to_yolo_format_converter.py --coco /path/to/coco/file \ 
+--images_dir /path/to/images/directory/ \ 
+--dest_dir /path/to/destination/directory/
+```
+2. **visualize_bbox_from_coco.py**: 
+
+This script displays an image with bounding box annotations from a COCO JSON file. Press random key on keyboard to switch to next bouning box around an object. Press `Esc` to exit the image display. The arguments required are:
+
+```bash
+python3 visualize_bbox_from_coco.py \ 
+--image_folder /path/to/image/folder/ \
+--annotation_file /path/to/annotation/file \
+--window_width 800 --window_height 600
+```
+3. **visualize_mask_and_bbox_from_yolo.py**: 
+
+This script visualizes segmentation masks and bounding boxes saved in YOLO format TXT files. It reads files from the 'bboxes' and 'polygons' folders. Press `n` to switch to another image with visualized bouning boxes and polygons. Press `Esc` to exit the image display.
+
+```bash
+python3 visualize_mask_and_bbox_from_yolo.py \ 
+--image_folder /path/to/image/folder/ \
+--bbox_folder /path/to/bboxes/folder/ \
+--polygon_folder /path/to/polygons/folder/
+```

--- a/tools/json_to_yolo_fromat_converter.py
+++ b/tools/json_to_yolo_fromat_converter.py
@@ -1,0 +1,76 @@
+import json
+from pathlib import Path
+import cv2
+import argparse
+import sys
+utilities_path = Path(__file__).resolve().parent.parent
+sys.path.append(str(utilities_path))
+from utilities.parsing_vaildator import dir_path, file_path
+
+
+def convert_json_to_yolo_format(annotation_path: file_path, images_dir_path: dir_path, dest_path: dir_path):
+    """
+    Converts segmentation mask and bouning box from standard polygon COCO format into YOLO format.
+    Args:
+        annotation_path: top left corner x coordinate,
+        images_dir_path: top left corner y coordinate,
+        dest_path: width
+    Returns:
+        Text files inside bboxes and polygons folders with YOLO format of segmentation masks and bboxes.
+    """
+    with open(annotation_path, 'r') as f:
+        dataset = json.load(f)
+
+    for img_info in dataset['images']:
+        img_name = img_info['file_name']
+        img_path = Path(images_dir_path) / img_name
+        img = cv2.imread(str(img_path))
+
+        img_h, img_w, _ = img.shape
+
+        anns = [ann for ann in dataset['annotations'] if ann['image_id'] == img_info['id']]
+
+        polygons_dest_dir = Path(dest_path) / 'polygons'
+        polygons_dest_dir.mkdir(parents=True, exist_ok=True)
+        bboxes_dest_dir = Path(dest_path) / 'bboxes'
+        bboxes_dest_dir.mkdir(parents=True, exist_ok=True)
+
+        with open(str(polygons_dest_dir / img_name).replace('.jpg', '.txt').replace('.JPG', '.txt').replace('.PNG', '.txt'), 'w') as poly_file, \
+             open(str(bboxes_dest_dir / img_name).replace('.jpg', '.txt').replace('.JPG', '.txt').replace('.PNG', '.txt'), 'w') as bbox_file:
+
+            for ann in anns:
+                row_poly = '0'
+                row_bbox = '0'
+
+                # Check if COCO file is in standard polygon COCO format
+                if isinstance(ann['segmentation'], list):
+                    # YOLO format from segmentation in the standard format
+                    for i in range(0, len(ann['segmentation'][0]), 2):
+                        row_poly += f' {ann["segmentation"][0][i] / img_w} {ann["segmentation"][0][i+1] / img_h}'
+                    row_poly += '\n'
+                    poly_file.write(row_poly)
+                else:
+                    # Skip annotations with segmentation in the RLE format
+                    continue
+
+                # YOLO format from bounding boxes
+                bbox = ann['bbox']
+                width = bbox[2] / img_w
+                height = bbox[3] / img_h
+
+                x_center = (bbox[0] + bbox[2] // 2) / img_w
+                y_center = (bbox[1] + bbox[3] // 2) / img_h
+
+                row_bbox += f' {x_center} {y_center} {width} {height}\n'
+                bbox_file.write(row_bbox)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Convert COCO format annotations to YOLO format.')
+    parser.add_argument('--coco', type=file_path, help="COCO file that describes objects.", required=True)
+    parser.add_argument('--images_dir', type=dir_path, required=True, help='Path to directory containing images.')
+    parser.add_argument('--dest_dir', type=dir_path, required=True, help='Path to destination directory for YOLO format annotations.')
+
+    args = parser.parse_args()
+
+    convert_json_to_yolo_format(args.coco, args.images_dir, args.dest_dir)

--- a/tools/visualize_bbox_from_coco.py
+++ b/tools/visualize_bbox_from_coco.py
@@ -1,0 +1,73 @@
+import os
+import cv2
+import json
+import sys
+from pathlib import Path
+import argparse
+utilities_path = Path(__file__).resolve().parent.parent
+sys.path.append(str(utilities_path))
+from utilities.parsing_vaildator import dir_path, file_path
+
+
+def visualize_bbox(image_folder: dir_path, annotation_file: file_path, window_width: int, window_height: int):
+    """
+    Visualizes bouning boxes saved in COCO annotation json file on image. 
+    Args:
+        image_folder: directory with images described inside COCO file,
+        annotation_file: file with standard polygon COCO annotations,
+        window_width: width of shown image,
+        window_height: height of shown image
+    Returns:
+        Imshow of an image with drawn rectangles around objects.
+    """
+    # Load annotations
+    with open(annotation_file, 'r') as f:
+        annotations = json.load(f)
+
+    # Load images
+    images = {image['id']: image['file_name'] for image in annotations['images']}
+    
+    # Display images with bounding boxes
+    for annotation in annotations['annotations']:
+        image_id = annotation['image_id']
+        image_file = os.path.join(image_folder, images[image_id])
+        image = cv2.imread(image_file)
+        
+        # Get bounding box coordinates
+        x, y, width, height = map(int, annotation['bbox'])
+        original_height, original_width, _ = image.shape
+        scale_x = window_width / original_width
+        scale_y = window_height / original_height
+
+        # Scale image and bounding box x, y coordinates
+        image = cv2.resize(image, (window_width, window_height))
+        x1 = int(x*scale_x)
+        y1 = int(y*scale_y)
+        x2 = int((x + width) * scale_x)
+        y2 = int((y + height) * scale_y)
+
+        # Draw bounding box on the image
+        cv2.rectangle(image, (x1, y1), (x2, y2), (0, 255, 0), 1)
+        
+        # Display the image
+        cv2.imshow('Image with Bounding Box', image)
+        
+        # Wait for key press
+        key = cv2.waitKey(0)
+        
+        # Check if the Esc key (key code 27) is pressed
+        if key == 27:
+            break
+        
+    cv2.destroyAllWindows()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Visualize bounding boxes on images.')
+    parser.add_argument('--image_folder', type=dir_path, help='Path to the image folder')
+    parser.add_argument('--annotation_file', type=file_path, help='Path to the annotation file')
+    parser.add_argument('--window_width', type=int, default=800, help='Width of the displayed window')
+    parser.add_argument('--window_height', type=int, default=600, help='Height of the displayed window')
+    args = parser.parse_args()
+
+    visualize_bbox(args.image_folder, args.annotation_file, args.window_width, args.window_height)

--- a/tools/visualize_mask_and_bbox_from_yolo.py
+++ b/tools/visualize_mask_and_bbox_from_yolo.py
@@ -1,0 +1,96 @@
+import cv2
+import numpy as np
+from glob import glob
+import random
+import argparse
+from pathlib import Path
+import sys
+utilities_path = Path(__file__).resolve().parent.parent
+sys.path.append(str(utilities_path))
+from utilities.parsing_vaildator import dir_path
+
+
+def visualize_yolo_annotations(image_folder: dir_path, bbox_folder: dir_path, polygon_folder: dir_path):
+    """
+    Visualizes bounding boxes and polygons on images.
+    Args:
+        image_folder: Path to the folder containing images.
+        bbox_folder: Path to the folder containing bounding box labels.
+        polygon_folder: Path to the folder containing polygon labels.
+    """
+    images = glob(image_folder + '/*.jpg')
+    random.shuffle(images)
+
+    idx = 0
+
+    while idx < len(images):
+        img_path = images[idx]
+
+        img = cv2.imread(img_path)
+
+        h, w = img.shape[:2]
+
+        bbox_label = img_path.replace(image_folder, bbox_folder).replace('.jpg', '.txt')
+        polygon_label = img_path.replace(image_folder, polygon_folder).replace('.jpg', '.txt')
+
+        with open(bbox_label, 'r') as f:
+            bbox_label = f.readlines()
+
+        with open(polygon_label, 'r') as f:
+            polygon_label = f.readlines()
+
+        for row in bbox_label:
+            row = row.split(' ')
+
+            x = float(row[1]) * w
+            y = float(row[2]) * h
+
+            width = float(row[3]) * w
+            height = float(row[4]) * h
+
+            x1 = int(x - width / 2)
+            y1 = int(y - height / 2)
+
+            x2 = int(x + width / 2)
+            y2 = int(y + height / 2)
+
+            cv2.rectangle(img, (x1, y1), (x2, y2), (0, 255, 0), 2)
+
+        for row in polygon_label:
+            row = row.split(' ')
+
+            points = []
+
+            for i in range(1, len(row), 2):
+                x = float(row[i]) * w
+                y = float(row[i + 1]) * h
+
+                points.append([x, y])
+
+            points = np.array([points], dtype=np.int32)
+
+            cv2.polylines(img, [points], True, (0, 0, 255), 2)
+
+        # Resize the image window
+        resized_img = cv2.resize(img, (1000, 800))  # Set your desired width and height
+
+        cv2.imshow('img', resized_img)
+
+        key = cv2.waitKey(0)
+
+        if key == 27:  # Esc key
+            break
+        elif key == ord('n'):  # 'n' key
+            idx += 1
+
+    cv2.destroyAllWindows()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Visualize bounding boxes and polygons on images.')
+    parser.add_argument('--image_folder', type=dir_path, help='Path to the image folder')
+    parser.add_argument('--bbox_folder', type=dir_path, help='Path to the folder containing bounding box labels')
+    parser.add_argument('--polygon_folder', type=dir_path, help='Path to the folder containing polygon labels')
+    args = parser.parse_args()
+
+    visualize_yolo_annotations(args.image_folder, args.bbox_folder, args.polygon_folder)

--- a/utilities/coco_parser.py
+++ b/utilities/coco_parser.py
@@ -56,10 +56,10 @@ def get_bbox_based_on_mask(mask: np.ndarray):
     [x, y, w, h] coordinates starting from left top corner.
     """
     object_points = np.where(mask > 0)
-    x = int(min(object_points[0]))
-    y = int(min(object_points[1]))
-    w = int(max(object_points[0]) - x + 1)
-    h = int(max(object_points[1]) - y + 1)
+    x = int(np.min(object_points[1]))
+    y = int(np.min(object_points[0]))
+    w = int(np.max(object_points[1]) - x + 1)
+    h = int(np.max(object_points[0]) - y + 1)
     return [x, y, w, h]
 
 


### PR DESCRIPTION
- script which converts standard COCO .json format into YOLO .txt files stored inside bboxes and polygons folders
- script which displays images with bounding boxes around each object from COCO .json file
- script which displays images with bounding boxes and polygons drawn around objects 
- fix with saving bounding boxes in COCO .json format (coco_parser.py and main.py)